### PR TITLE
Makes links to github appear in a new window

### DIFF
--- a/administrator/components/com_patchtester/views/pulls/tmpl/default_items.php
+++ b/administrator/components/com_patchtester/views/pulls/tmpl/default_items.php
@@ -24,7 +24,8 @@ foreach($this->items as $i => $item) :
     <td>
         <a class="icon icon16-github hasTip"
            title="<?php echo JText::_('COM_PATCHTESTER_OPEN_IN_GITHUB'); ?>"
-           href="<?php echo $item->html_url; ?>">
+           href="<?php echo $item->html_url; ?>"
+           target="_blank">
             <?php echo $item->title; ?>
         </a>
     </td>


### PR DESCRIPTION
Now the links make your joomla disapear because you load the github page in same page. Adding the target to link it opens in a new window.
