### PR TITLE
Icon for the Toolbar in 3.x

### DIFF
--- a/administrator/components/com_patchtester/views/pulls/view.html.php
+++ b/administrator/components/com_patchtester/views/pulls/view.html.php
@@ -116,12 +116,8 @@ class PatchtesterViewPulls extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		JToolBarHelper::title(JText::_('COM_PATCHTESTER'), 'patchtester');
+		JToolBarHelper::title(JText::_('COM_PATCHTESTER'), '');
 		JToolbarHelper::custom('purge', 'delete.png', 'delete_f2.png', 'COM_PATCHTESTER_PURGE_CACHE', false);
 		JToolBarHelper::preferences('com_patchtester');
-
-		JFactory::getDocument()->addStyleDeclaration(
-			'.icon-48-patchtester {background-image: url(components/com_patchtester/assets/images/icon-48-patchtester.png);}'
-		);
 	}
 }


### PR DESCRIPTION
Currently we have no icon at the toolbar. This PR will change (or more fallback) to a circle with a point in it. As the others that are in the images folder don't look so good at this place i think.

But if we want to have e.g. the red beetle (https://github.com/joomla-extensions/patchtester/tree/master/administrator/components/com_patchtester/assets/images)

I can change this PR. Let me know :)
Thanks :)
