### PR TITLE
Updating installation script

### DIFF
--- a/administrator/components/com_patchtester/script.php
+++ b/administrator/components/com_patchtester/script.php
@@ -147,7 +147,7 @@ class Com_PatchtesterInstallerScript
 			if (is_dir($tmplRoot))
 			{
 				// If there's a failure in copying the overrides, log it to the error array
-				if (!JFolder::copy($source, $destination))
+				if (!JFolder::copy($source, $destination, '', true))
 				{
 					$errorTemplates[] = ucfirst($template);
 				}


### PR DESCRIPTION
If we re-install PatchTester on a website, the copy of the folder failed because the destination folder already exists.
Using the option "force", the JFolder::copy won't generate an exception and copy the files even if the destination folder already exist.
Regarding the code of JFolder::copy, it can be useful to put this call in a try/catch ; otherwise the exception stop the all process.

Regards,
Jerome - Obsidev/HikaShop
