### PR TITLE
Show environment errors if there are any.

### DIFF
--- a/administrator/components/com_patchtester/views/pulls/view.html.php
+++ b/administrator/components/com_patchtester/views/pulls/view.html.php
@@ -86,6 +86,12 @@ class PatchtesterViewPulls extends JViewLegacy
 				return false;
 			}
 		}
+		else
+		{
+			JError::raiseError(500, implode("\n", $this->envErrors));
+
+			return false;
+		}
 
 		$this->addToolbar();
 


### PR DESCRIPTION
If there are any errors with the environment, for example OpenSSL is not activated, patchtester now throws a fatal error or WSOD. This patch fixes this by presenting the user with the actual error message.