### PR TITLE
Change info icon to bootstrap icon

### DIFF
--- a/administrator/components/com_patchtester/views/pulls/tmpl/default_items.php
+++ b/administrator/components/com_patchtester/views/pulls/tmpl/default_items.php
@@ -8,6 +8,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.tooltip');
+
 /** @type  PatchtesterViewPulls  $this */
 
 foreach ($this->items as $i => $item) :


### PR DESCRIPTION
I think the bootstrap icon `<i class="icon-info"></i>` looks better than the standard Joomla! info icon
