### PR TITLE
Proposal fix for: Don't throw an exception when you can't connect to server Ref:#57

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Helper.php
+++ b/administrator/components/com_patchtester/PatchTester/Helper.php
@@ -20,11 +20,13 @@ abstract class Helper
 	/**
 	 * Initializes the JGithub object
 	 *
+	 * @param  bool  Use the User enterd PW yes or no
+	 *
 	 * @return  \JGithub
 	 *
 	 * @since   2.0
 	 */
-	public static function initializeGithub()
+	public static function initializeGithub($use_user_pw)
 	{
 		$params = \JComponentHelper::getParams('com_patchtester');
 
@@ -35,8 +37,8 @@ abstract class Helper
 		{
 			$options->set('gh.token', $params->get('gh_token', ''));
 		}
-		// Set the username and password if set in the params
-		elseif ($params->get('gh_user', '') && $params->get('gh_password'))
+		// Set the username and password if set in the params and not disabled by the code
+		elseif ($params->get('gh_user', '') && $params->get('gh_password') && $use_user_pw == true)
 		{
 			$options->set('api.username', $params->get('gh_user', ''));
 			$options->set('api.password', $params->get('gh_password', ''));

--- a/administrator/components/com_patchtester/PatchTester/Helper.php
+++ b/administrator/components/com_patchtester/PatchTester/Helper.php
@@ -33,7 +33,7 @@ abstract class Helper
 		$options = new Registry;
 
 		// If an API token is set in the params, use it for authentication
-		if ($params->get('gh_token', ''))
+		if ($params->get('gh_token', '') && $use_user_pw == true)
 		{
 			$options->set('gh.token', $params->get('gh_token', ''));
 		}

--- a/administrator/components/com_patchtester/PatchTester/Helper.php
+++ b/administrator/components/com_patchtester/PatchTester/Helper.php
@@ -26,7 +26,7 @@ abstract class Helper
 	 *
 	 * @since   2.0
 	 */
-	public static function initializeGithub($use_user_pw)
+	public static function initializeGithub($use_user_pw = true)
 	{
 		$params = \JComponentHelper::getParams('com_patchtester');
 

--- a/administrator/components/com_patchtester/PatchTester/Helper.php
+++ b/administrator/components/com_patchtester/PatchTester/Helper.php
@@ -26,19 +26,19 @@ abstract class Helper
 	 *
 	 * @since   2.0
 	 */
-	public static function initializeGithub($use_user_pw = true)
+	public static function initializeGithub($useUserPw = true)
 	{
 		$params = \JComponentHelper::getParams('com_patchtester');
 
 		$options = new Registry;
 
 		// If an API token is set in the params, use it for authentication
-		if ($params->get('gh_token', '') && $use_user_pw == true)
+		if ($params->get('gh_token', '') && $useUserPw == true)
 		{
 			$options->set('gh.token', $params->get('gh_token', ''));
 		}
 		// Set the username and password if set in the params and not disabled by the code
-		elseif ($params->get('gh_user', '') && $params->get('gh_password') && $use_user_pw == true)
+		elseif ($params->get('gh_user', '') && $params->get('gh_password') && $useUserPw == true)
 		{
 			$options->set('api.username', $params->get('gh_user', ''));
 			$options->set('api.password', $params->get('gh_password', ''));

--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -125,7 +125,7 @@ class PullModel extends \JModelBase
 	public function apply($id)
 	{
 		// Get the Github object
-		$github = Helper::initializeGithub();
+		$github = Helper::initializeGithub(true);
 
 		// Only act if there are API hits remaining
 		if ($github->authorization->getRateLimit()->rate->remaining > 0)

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -289,7 +289,7 @@ class PullsModel extends \JModelDatabase
 	public function requestFromGithub()
 	{
 		// Get the Github object
-		$github = Helper::initializeGithub();
+		$github = Helper::initializeGithub(true);
 
 		// If over the API limit, we can't build this list
 		if ($github->authorization->getRateLimit()->rate->remaining > 0)

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -313,7 +313,19 @@ class PullsModel extends \JModelDatabase
 				}
 				catch (\DomainException $e)
 				{
-					throw new \RuntimeException(\JText::sprintf('COM_PATCHTESTER_ERROR_GITHUB_FETCH', $e->getMessage()));
+					$github = Helper::initializeGithub(false);
+					
+					\JFactory::getApplication()->enqueueMessage(\JText::sprintf('COM_PATCHTESTER_ERROR_GITHUB_FETCH', $e->getMessage()), 'notice');
+					
+					try
+					{
+						$items  = $github->pulls->getList($this->getState()->get('github_user'), $this->getState()->get('github_repo'), 'open', $page, 100);
+					
+					}
+					catch (\DomainException $e)
+					{
+						throw new \RuntimeException(\JText::sprintf('COM_PATCHTESTER_ERROR_GITHUB_FETCH', $e->getMessage()));
+					}
 				}
 
 				$count = is_array($items) ? count($items) : 0;

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -315,7 +315,7 @@ class PullsModel extends \JModelDatabase
 				{
 					$github = Helper::initializeGithub(false);
 					
-					\JFactory::getApplication()->enqueueMessage(\JText::sprintf('COM_PATCHTESTER_ERROR_GITHUB_FETCH', $e->getMessage()), 'notice');
+					\JFactory::getApplication()->enqueueMessage(\JText::sprintf('COM_PATCHTESTER_ERROR_GITHUB_FETCH', $e->getMessage()), 'error');
 					
 					try
 					{


### PR DESCRIPTION
see: https://github.com/joomla-extensions/patchtester/issues/57

@wilsonge @mbabker can you have a look into it?

I'm not 100% sure if we can simple add here https://github.com/zero-24/patchtester/blob/patch-1/administrator/components/com_patchtester/PatchTester/Helper.php#L29 one param and / or how this function is called.

### What this should do

- User enter the PW/Username
- We try to connect github and fail
- We create a github objekt without PW / Username (maybe we need to add the token here too?)
- We try to connect github
- If it fail we have throw a RuntimeException
- if it is the first connect to github fails we send the message 'Please enter User namen' and 'can't connect to github' as messages.