### PR TITLE
Increase PHP max execution time to 5 minute

### DIFF
--- a/administrator/components/com_patchtester/patchtester.php
+++ b/administrator/components/com_patchtester/patchtester.php
@@ -31,6 +31,9 @@ if ($task === '')
 
 $class = '\\PatchTester\\Controller\\' . ucfirst(strtolower($task)) . 'Controller';
 
+// Increase PHP max execution time to 5 minute
+ini_set('max_execution_time', 300);
+
 // Instantiate and execute the controller
 $controller = new $class($app->input, $app);
 $controller->execute();


### PR DESCRIPTION
Lately I was unable to use com_patchtester (code from 'master') as I was getting errors of max execution time (30 seconds) exceeded.

I don't know if this is the CORRECT solution, but with this I solved my problems...