### PR TITLE
PostgreSQL - error apply/revert a patch

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -128,10 +128,11 @@ class PullsModel extends \JModelDatabase
 
 		if (!empty($search))
 		{
+			$searchid = $search;
 			$search = $db->quote('%' . $db->escape($search, true) . '%');
 			$query->where(
 				'(' . $db->quoteName('a.title') . ' LIKE ' . $search . ') OR ' .
-				'(' . $db->quoteName('a.pull_id') . ' LIKE ' . $search . ') '
+				'(' . $db->quoteName('a.pull_id') . ' = ' . $searchid . ') '
 			);
 		}
 


### PR DESCRIPTION
as reported #47 you are unable to apply a patch on postgresql
the issue arise cause we are using LIKE on a bigint field ```pull_id```

```
WHERE ("a"."title" LIKE '%6263%') OR ("a"."pull_id" LIKE '%6263%')
```
we need to use ``` = ``` instead