### PR TITLE
varchar too long for postgresql

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -128,7 +128,7 @@ class PullsModel extends \JModelDatabase
 
 		if (!empty($search))
 		{
-			$searchid = $search;
+			$searchid = (int) $search;
 			$search = $db->quote('%' . $db->escape($search, true) . '%');
 			$query->where(
 				'(' . $db->quoteName('a.title') . ' LIKE ' . $search . ') OR ' .

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -343,7 +343,7 @@ class PullsModel extends \JModelDatabase
 		foreach ($pulls as $pull)
 		{
 			// Build the data object to store in the database
-			$pullData = array($pull->number, $pull->title, $pull->body, $pull->html_url);
+			$pullData = array($pull->number, substr($pull->title,0,100), substr($pull->body,0,5000), $pull->html_url);
 			$data[] = implode($this->getDb()->quote($pullData), ',');
 		}
 


### PR DESCRIPTION
i've expereinced when fetch data 
![p341 administration joomla patch tester](https://cloud.githubusercontent.com/assets/181681/7000798/b1488b86-dc2c-11e4-8230-6f3e7103258f.png)

when some pr have title > 100 and / or body > 5000
guess same fix on  pull_url ?
cause
```sql
title character varying(100) NOT NULL,
description character varying(5000) NOT NULL DEFAULT ''::character varying,
pull_url character varying(255) NOT NULL,
```