### PR TITLE
core.js is needed

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/View/Fetch/tmpl/default.php
+++ b/administrator/components/com_patchtester/PatchTester/View/Fetch/tmpl/default.php
@@ -9,6 +9,7 @@
 /** @type  \PatchTester\View\DefaultHtmlView  $this */
 
 JHtml::_('jquery.framework');
+JHtml::_('behavior.core');
 JHtml::_('script', 'com_patchtester/fetcher.js', false, true);
 
 ?>


### PR DESCRIPTION
@mbabker fetcher.js is crying that Joomla is not defined. This is due to the fact that behavior.framework was loading as well core.js, but not anymore. Therefore we should load it ourselves. Sorry I didn’t catch that before 😕