### PR TITLE
Travis on PHP 7 and the new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ before_script:
   - composer install
 
 script:
-  - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml
   - if [ "$RUN_PHPCS" == "yes" ]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,25 @@
+# Forces new Travis-CI Infrastructure
+sudo: false
+
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+env:
+  global:
+    - RUN_PHPCS="no"
 
 matrix:
-  allow_failures:
+  include:
+    - php: 5.3
+      env: RUN_PHPCS="yes"
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
     - php: 7.0
 
 before_script:
+  # Make sure all dev dependencies are installed
   - composer install
 
 script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '7.0' ]; then vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi"
+  - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml
+  - if [ "$RUN_PHPCS" == "yes" ]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - composer install
 
 script:
-  - if [ "$RUN_PHPCS" == "yes" ]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi
+  - if [ "$RUN_PHPCS" == "yes" ]; then then vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - composer install
 
 script:
-  - if [ "$RUN_PHPCS" == "yes" ]; then then vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi
+  - if [ "$RUN_PHPCS" == "yes" ]; then vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla --ignore=./*tmpl/* administrator/components/com_patchtester; fi


### PR DESCRIPTION
### What this does
enable Travis on PHP 7 and use the new infrastructure, PHP CS only on PHP 5.3

### How to test
see that the unit test still works. ;)