### PR TITLE
Move the is_numeric($search) to it's own condition

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -134,7 +134,7 @@ class PullsModel extends \JModelDatabase
 			}
 			elseif (is_numeric($search))
 			{
-				$query->where('(' . $db->quoteName('a.id') . ' LIKE ' . (int) $search . ')');
+				$query->where('(' . $db->quoteName('a.id') . ' LIKE "% ' . (int) $search . '%")');
 			}
 			else
 			{

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -134,7 +134,7 @@ class PullsModel extends \JModelDatabase
 			}
 			elseif (is_numeric($search))
 			{
-				$query->where('(' . $db->quoteName('a.id')  . ' LIKE ' . (int) $search. ')');
+				$query->where('(' . $db->quoteName('a.id') . ' LIKE ' . (int) $search . ')');
 			}
 			else
 			{

--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -128,9 +128,13 @@ class PullsModel extends \JModelDatabase
 
 		if (!empty($search))
 		{
-			if (stripos($search, 'id:') === 0 || is_numeric($search))
+			if (stripos($search, 'id:') === 0)
 			{
 				$query->where($db->quoteName('a.id') . ' = ' . (int) substr($search, 3));
+			}
+			elseif (is_numeric($search))
+			{
+				$query->where('(' . $db->quoteName('a.id')  . ' LIKE ' . (int) $search. ')');
 			}
 			else
 			{


### PR DESCRIPTION
Need to move the `is_numeric($search)` check to it's own condition since we are not striping off the first 3 characters when searching by a pure numeric case
Also better to search with a "like" rather than a direct equals so we can match partial number sequences.

This resolves an unnoticed inconsistency with #118 