### PR TITLE
Use InnoDB and utf8mb4_unicode_ci in the patchtester too

### DIFF
--- a/administrator/components/com_patchtester/install/sql/mysql/install.sql
+++ b/administrator/components/com_patchtester/install/sql/mysql/install.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS `#__patchtester_pulls`;
-
 CREATE TABLE IF NOT EXISTS `#__patchtester_pulls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pull_id` int(11) NOT NULL,
@@ -9,8 +7,6 @@ CREATE TABLE IF NOT EXISTS `#__patchtester_pulls` (
   `sha` varchar(40) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
-
-DROP TABLE IF EXISTS `#__patchtester_tests`;
 
 CREATE TABLE IF NOT EXISTS `#__patchtester_tests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/administrator/components/com_patchtester/install/sql/mysql/install.sql
+++ b/administrator/components/com_patchtester/install/sql/mysql/install.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS `#__patchtester_pulls`;
+
 CREATE TABLE IF NOT EXISTS `#__patchtester_pulls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pull_id` int(11) NOT NULL,
@@ -6,7 +8,9 @@ CREATE TABLE IF NOT EXISTS `#__patchtester_pulls` (
   `pull_url` varchar(255) NOT NULL,
   `sha` varchar(40) NOT NULL,
   PRIMARY KEY (`id`)
-) DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+DROP TABLE IF EXISTS `#__patchtester_tests`;
 
 CREATE TABLE IF NOT EXISTS `#__patchtester_tests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -17,4 +21,4 @@ CREATE TABLE IF NOT EXISTS `#__patchtester_tests` (
   `applied_version` varchar(25) NOT NULL,
   `comments` varchar(3000) NOT NULL,
   PRIMARY KEY (`id`)
-) DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/administrator/components/com_patchtester/script.php
+++ b/administrator/components/com_patchtester/script.php
@@ -19,7 +19,7 @@ class Com_PatchtesterInstallerScript
 	 * @var    string
 	 * @since  2.0
 	 */
-	protected $minCmsVersion = '3.3.0';
+	protected $minCmsVersion = '3.5.0';
 
 	/**
 	 * Array of templates with supported overrides


### PR DESCRIPTION
#### Summary of Changes

Create patchtester tables with InnoDB and utf8mb4_unicode_ci.

#### Testing Instructions

1. Install patchtester beta 4 with this patch integrated on a joomla latest staging (clean install). 
[com_patchtester-beta-4-ut8mb4.zip](https://github.com/joomla-extensions/patchtester/files/154814/com_patchtester-beta-4-ut8mb4.zip)

2. Check if everything is working fine.

#### Observations

To not cause issues added a drop to existing tables first.
Not an expert in databases, so please check if anything more is needed.