### PR TITLE
notice, not info

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
+++ b/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
@@ -120,7 +120,7 @@ class ResetController extends AbstractController
 			else
 			{
 				$msg  = \JText::_('COM_PATCHTESTER_RESET_OK');
-				$type = 'info';
+				$type = 'notice';
 			}
 		}
 		catch (\Exception $e)


### PR DESCRIPTION
the reset message type should be `notice`, not `info`

