### PR TITLE
Remove the frontend file

### DIFF
--- a/administrator/components/com_patchtester/script.php
+++ b/administrator/components/com_patchtester/script.php
@@ -33,6 +33,11 @@ class Com_PatchtesterInstallerScript extends JInstallerScript
 
 		$this->deleteFolders = array(
 			'/administrator/components/com_patchtester/PatchTester/Table',
+			'/components/com_patchtester',
+		);
+
+		$this->deleteFiles = array(
+			'components/com_patchtester/patchtester.php',
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes

This removes the frontend file `components/com_patchtester/patchtester.php` it contains nothing and is not longer included into the package: https://github.com/joomla-extensions/patchtester/blob/master/build/patchtester/build.sh

#### Testing Instructions

This can't be tested.