### PR TITLE
Postgresql - bigint field "pull_id" doesn't like LIKE operator - #175

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -108,7 +108,7 @@ class PullsModel extends \JModelDatabase
 			}
 			elseif (is_numeric($search))
 			{
-				$query->where('a.pull_id LIKE ' . $db->quote('%' . (int) $search . '%'));
+				$query->where('a.pull_id = ' . (int) $search);
 			}
 			else
 			{


### PR DESCRIPTION
Pull Request for Issue #175 .

#### Summary of Changes
In standard SQL bigint field "pull_id" doesn't like `LIKE` operator

#### Testing Instructions
install com_patchtester, and check that the search work as expected
