### PR TITLE
Change media version when applying/reverting a patch

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -326,6 +326,10 @@ class PullModel extends \JModelDatabase
 				->where($db->quoteName('pull_id') . ' = ' . (int) $id)
 		)->execute();
 
+		// Change the media version
+		$version = new \JVersion;
+		$version->refreshMediaVersion();
+
 		return true;
 	}
 
@@ -439,6 +443,10 @@ class PullModel extends \JModelDatabase
 					break;
 			}
 		}
+
+		// Change the media version
+		$version = new \JVersion;
+		$version->refreshMediaVersion();
 
 		return $this->removeTest($testRecord);
 	}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-extensions/patchtester/issues/177.

#### Summary of Changes

Auto changes media version when appluing/reverting a patch.

#### Testing Instructions

1. Check the media version in page source
2. Apply one patch
3. Check the media version in page source changed
3. Revert the patch
4. Check the media version in page source changed again
