### PR TITLE
Add 3.0.0 beta to the update server with beta update tag

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -16,4 +16,20 @@
 		</tags>
 		<targetplatform name="joomla" version="3.[56789]" />
 	</update>
+	<update>
+		<name>Patch Tester Component</name>
+		<description>Joomla! CMS Patch Tester Component</description>
+		<element>com_patchtester</element>
+		<type>component</type>
+		<version>3.0.0-beta3</version>
+		<client>administrator</client>
+		<infourl title="Patch Tester Component">https://github.com/joomla-extensions/patchtester/releases/tag/3.0.0-beta3</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/patchtester/releases/download/3.0.0-beta3/com_patchtester.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>beta</tag>
+		</tags>
+		<targetplatform name="joomla" version="3.[56789]" />
+	</update>
 </updates>

--- a/manifest.xml
+++ b/manifest.xml
@@ -30,6 +30,6 @@
 		<tags>
 			<tag>beta</tag>
 		</tags>
-		<targetplatform name="joomla" version="3.[56789]" />
+		<targetplatform name="joomla" version="3.[789]" />
 	</update>
 </updates>


### PR DESCRIPTION
#### Summary of Changes

Add 3.0.0 beta to the update server with beta update tag

#### Testing Instructions

Merge this set the update stability in the backend to beta you see the update.
Switch back to stable (default) no update should be shown.