### PR TITLE
[4.0] Change 'Table Options' to 'Filter Options'

### DIFF
--- a/administrator/templates/atum/html/com_patchtester/pulls/default.php
+++ b/administrator/templates/atum/html/com_patchtester/pulls/default.php
@@ -59,7 +59,7 @@ $colSpan       = $this->trackerAlias !== false ? 8 : 7;
 							</button>
 							<div class="btn-group">
 								<button type="button" class="btn btn-primary hasTooltip js-stools-btn-filter">
-									<?php echo \JText::_('JTABLE_OPTIONS'); ?>
+									<?php echo \JText::_('JFILTER_OPTIONS'); ?>
 									<span class="fa fa-caret-down" aria-hidden="true"></span>
 								</button>
 							</div>


### PR DESCRIPTION
#### Summary of Changes
The ```Table Options``` button in the patchtester component is changed to ```Filter Options```( like for any other Joomla component)

#### Expected Result
![PT_new](https://user-images.githubusercontent.com/34353697/54386225-7d370880-46be-11e9-848e-fe74748677fd.png)

#### Actual Result
![PT_old](https://user-images.githubusercontent.com/34353697/54386235-82945300-46be-11e9-971e-cc729b2dd956.png)

#### Documentation Changes 
None