### PR TITLE
Block use on 4.0

### DIFF
--- a/administrator/components/com_patchtester/language/en-GB/en-GB.com_patchtester.sys.ini
+++ b/administrator/components/com_patchtester/language/en-GB/en-GB.com_patchtester.sys.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_PATCHTESTER="Joomla! Patch Tester"
+COM_PATCHTESTER_CANNOT_INSTALL_ON_JOOMLA_4="Due to changes in Joomla! 4, the patch tester component cannot be used at this time."
 COM_PATCHTESTER_COULD_NOT_INSTALL_OVERRIDES="Could not install the template overrides for the following templates: %s"
 COM_PATCHTESTER_COULD_NOT_REMOVE_OVERRIDES="Could not remove the template overrides for the following templates: %s"
 COM_PATCHTESTER_XML_DESCRIPTION="Component for pull request management testing"

--- a/administrator/components/com_patchtester/script.php
+++ b/administrator/components/com_patchtester/script.php
@@ -9,6 +9,8 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Adapter\ComponentAdapter;
 use Joomla\CMS\Installer\InstallerScript;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 /**
  * Installation class to perform additional changes during install/uninstall/update
@@ -43,6 +45,34 @@ class Com_PatchtesterInstallerScript extends InstallerScript
 			'/administrator/components/com_patchtester/PatchTester/Table',
 			'/components/com_patchtester',
 		);
+	}
+
+	/**
+	 * Function called before extension installation/update/removal procedure commences
+	 *
+	 * @param   string            $type    The type of change (install, update or discover_install, not uninstall)
+	 * @param   ComponentAdapter  $parent  The class calling this method
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function preflight($type, $parent)
+	{
+		$return = parent::preflight($type, $parent);
+
+		if ($return)
+		{
+			// Block installation on 4.0 due to the MVC code this component relies on being removed
+			if (version_compare(JVERSION, '4.0', '>='))
+			{
+				Log::add(Text::_('COM_PATCHTESTER_CANNOT_INSTALL_ON_JOOMLA_4'), Log::WARNING, 'jerror');
+
+				return false;
+			}
+		}
+
+		return $return;
 	}
 
 	/**


### PR DESCRIPTION
If https://github.com/joomla/joomla-cms/pull/24714 is accepted then this component is unusable on 4.0.  Draft PR ready to go in case it is merged.