### PR TITLE
Correct 2.0.0 schema updates

### DIFF
--- a/administrator/components/com_patchtester/install/sql/updates/mysql/2.0.0.sql
+++ b/administrator/components/com_patchtester/install/sql/updates/mysql/2.0.0.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `#__patchtester_pulls` (
   `description` varchar(150) NOT NULL DEFAULT '',
   `pull_url` varchar(255) NOT NULL,
   `sha` varchar(40) NOT NULL DEFAULT '',
-  `branch` varchar(255) NOT NULL DEFAULT '',
+  `is_rtc` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 

--- a/administrator/components/com_patchtester/install/sql/updates/postgresql/2.0.0.sql
+++ b/administrator/components/com_patchtester/install/sql/updates/postgresql/2.0.0.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS "#__patchtester_pulls" (
   "description" character varying(150) DEFAULT '' NOT NULL,
   "pull_url" character varying(255) NOT NULL,
   "sha" character varying(40) DEFAULT '' NOT NULL,
-  "branch" character varying(255) DEFAULT '' NOT NULL,
+  "is_rtc" smallint DEFAULT 1 NOT NULL,
   PRIMARY KEY ("id")
 );
 

--- a/administrator/components/com_patchtester/install/sql/updates/sqlsrv/2.0.0.sql
+++ b/administrator/components/com_patchtester/install/sql/updates/sqlsrv/2.0.0.sql
@@ -5,7 +5,7 @@ CREATE TABLE [#__patchtester_pulls] (
   [description] [nvarchar](150) NOT NULL DEFAULT '',
   [pull_url] [nvarchar](255) NOT NULL,
   [sha] [nvarchar](40) NOT NULL DEFAULT '',
-  [branch] [nvarchar](255) NOT NULL DEFAULT '',
+  [is_rtc] [smallint] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__patchtester_pulls] PRIMARY KEY CLUSTERED
 (
   [id] ASC


### PR DESCRIPTION
Pull Request for Issue [#108 (comment)](https://github.com/joomla-extensions/patchtester/issues/186#issuecomment-473627667).

#### Summary of Changes

Correct 2.0.0 schema updates so that they fit to 2.0.0 new installation and so the 3.0.0 schema updates won't fail.

#### Testing Instructions

Try to install patch tester 3.0.0 beta 4 on Joomla 3.9.6.

Result: See Issue [#108 (comment)](https://github.com/joomla-extensions/patchtester/issues/186#issuecomment-473627667).

Do the same with a patched package modified by the changes in this PR.

You can create such package by downloading the zip, unpacking it, changing the files by those downloaded from this PR, packing back into a new zip in the same way and install that zip with upload file.

Result: Installation successful.