### PR TITLE
[4.0] Fix PHP warning "failed to open stream: No such file or di…

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -248,7 +248,7 @@ class PullModel extends AbstractModel
 		File::delete($zipPath);
 
 		// Get files from deleted_logs
-		$deletedFiles = (file($delLogPath) ? file($delLogPath) : array());
+		$deletedFiles = (file_exists($delLogPath) ? file($delLogPath) : array());
 		$deletedFiles = array_map('trim', $deletedFiles);
 
 		if (file_exists($delLogPath))


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

See the diff.

#### Testing Instructions

Try to apply a patch which does not delete any files so that there would not be any list of deleted files and watch the PHP error log, having log into file enabled in php.ini and error logging set to maximum possible (E_ALL).

#### Expected result:

No PHP warning.

#### Actual result:

> PHP Warning:  file(/home/richard/lamp/public_html/test-2/tmp/26614/deleted_files.log): failed to open stream: No such file or directory in /home/richard/lamp/public_html/test-2/administrator/components/com_patchtester/PatchTester/Model/PullModel.php on line 251