### PR TITLE
[4.0] Fix applying patches failing on Linux hosts

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -269,9 +269,9 @@ class PullModel extends AbstractModel
 		{
 			try
 			{
-				$filePath = explode("\\", Path::clean($file));
+				$filePath = explode(DIRECTORY_SEPARATOR, Path::clean($file));
 				array_pop($filePath);
-				$filePath = implode("\\", $filePath);
+				$filePath = implode(DIRECTORY_SEPARATOR, $filePath);
 
 				// Deleted_logs returns files as well as folder, if value is folder, unset and skip
 				if (is_dir(JPATH_ROOT . "/$file"))


### PR DESCRIPTION
Pull Request for Issue #240 .

#### Summary of Changes

Use DIRECTORY_SEPARATOR for expode and implode of the path to files to be backed up so that later creating the directories for the backups doesn't fail.

I don't know if this is the right way to fix it, but it works here.

#### Testing Instructions

See issue #240 .