### PR TITLE
[4.0] Fix PHP notices

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
+++ b/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
@@ -35,7 +35,7 @@ class ResetController extends AbstractController
 	{
 		try
 		{
-			$hasErrors = false;
+			$hasErrors     = false;
 			$revertErrored = false;
 
 			$pullModel  = new PullModel(null, Factory::getDbo());

--- a/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
+++ b/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
@@ -36,6 +36,7 @@ class ResetController extends AbstractController
 		try
 		{
 			$hasErrors = false;
+			$revertErrored = false;
 
 			$pullModel  = new PullModel(null, Factory::getDbo());
 			$pullsModel = new PullsModel($this->context, null, Factory::getDbo());
@@ -46,7 +47,6 @@ class ResetController extends AbstractController
 
 			if (count($appliedPatches['git']))
 			{
-				$revertErrored = false;
 
 				// Let's try to cleanly revert all applied patches
 				foreach ($appliedPatches['git'] as $patch)
@@ -64,8 +64,6 @@ class ResetController extends AbstractController
 
 			if (count($appliedPatches['ci']))
 			{
-				$revertErrored = false;
-
 				// Let's try to cleanly revert all applied patches with ci
 				foreach ($appliedPatches['ci'] as $patch)
 				{

--- a/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
+++ b/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
@@ -47,7 +47,6 @@ class ResetController extends AbstractController
 
 			if (count($appliedPatches['git']))
 			{
-
 				// Let's try to cleanly revert all applied patches
 				foreach ($appliedPatches['git'] as $patch)
 				{

--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -596,7 +596,7 @@ class PullModel extends AbstractModel
 		$params = ComponentHelper::getParams('com_patchtester');
 
 		// Decide based on repository settings whether patch will be applied through Github or CIServer
-		if (version_compare(JVERSION, "4", "ge") && ((bool) $params->get('ci_switch', 1) || $id === $this->getPatchChain($id)->insert_id))
+		if (version_compare(JVERSION, "4", "ge") && ((bool) $params->get('ci_switch', 1) || $id === $this->getPatchChain($id))->insert_id)
 		{
 			return $this->revertWithCIServer($id);
 		}


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

Fixes following PHP notices:

> PHP Notice:  Trying to get property 'insert_id' of non-object in /joomla-cms-4.0-dev/administrator/components/com_patchtester/PatchTester/Model/PullModel.php on line 599
> PHP Notice:  Undefined variable: revertErrored in /joomla-cms-4.0-dev/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php on line 84
> 

#### Testing Instructions

Code review: The mistakes are obvious:

- In ResetController.php a variable is checked also in case if never initialized.
- In PullModel.php a closing paranthesis `)` is at the wrong place. The function which is called expects an integer parameter and returns an object.

Or apply and revert a PR and check the PHP error log or error display, with PHP error reporting set to maximum or development.