### PR TITLE
Fix PHP notice in ResetController

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
+++ b/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php
@@ -35,7 +35,8 @@ class ResetController extends AbstractController
 	{
 		try
 		{
-			$hasErrors = false;
+			$hasErrors     = false;
+			$revertErrored = false;
 
 			$pullModel  = new PullModel(null, Factory::getDbo());
 			$pullsModel = new PullsModel($this->context, null, Factory::getDbo());
@@ -46,8 +47,6 @@ class ResetController extends AbstractController
 
 			if (count($appliedPatches['git']))
 			{
-				$revertErrored = false;
-
 				// Let's try to cleanly revert all applied patches
 				foreach ($appliedPatches['git'] as $patch)
 				{
@@ -64,8 +63,6 @@ class ResetController extends AbstractController
 
 			if (count($appliedPatches['ci']))
 			{
-				$revertErrored = false;
-
 				// Let's try to cleanly revert all applied patches with ci
 				foreach ($appliedPatches['ci'] as $patch)
 				{


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

Fixes following PHP notice:

> PHP Notice:  Undefined variable: revertErrored in /joomla-cms-4.0-dev/administrator/components/com_patchtester/PatchTester/Controller/ResetController.php on line 84
>

#### Testing Instructions

Code review: The mistake is obvious. Variable `$revertErrored` is checked even if not set before. Moved initialization of this variable out from the 2 if clauses up to the top.