### PR TITLE
[4.0] Use HttpFactory to fetch zip file from CI server

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -220,13 +220,13 @@ class PullModel extends AbstractModel
 			return false;
 		}
 
+		$version    = new Version;
+		$httpOption = new Registry;
+		$httpOption->set('userAgent', $version->getUserAgent('Joomla', true, false));
+
 		// Try to download the zip file
 		try
 		{
-			$version    = new Version;
-			$httpOption = new Registry;
-			$httpOption->set('userAgent', $version->getUserAgent('Joomla', true, false));
-
 			$http = HttpFactory::getHttp($httpOption);
 			$result = $http->get($serverZipPath);
 		}


### PR DESCRIPTION
Pull Request for Issue #233 .

#### Summary of Changes

See the title.

#### Testing Instructions

Verify that applying and reverting a PR which requires the CI server (e.g. PR [https://github.com/joomla/joomla-cms/pull/26845](https://github.com/joomla/joomla-cms/pull/26845)) still works without issues.

**Important note:** Do **NOT** test with a PR which changes composer dependencies like e.g. PR [https://github.com/joomla/joomla-cms/pull/26440](https://github.com/joomla/joomla-cms/pull/26440). There happens a fatal error which seems to be caused by missing or removed 3rd party libraries. This is the case with and without this PR here, am investigating further.

You need the latest patchtester release [https://github.com/joomla-extensions/patchtester/releases/tag/4.0.0-beta2](https://github.com/joomla-extensions/patchtester/releases/tag/4.0.0-beta2) plus the changes from PR's merged after that release + the changes of this PR here.

You can download a patched patchtester 4.0.0-beta2 with all these changes here: [https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-3.zip](https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-3.zip). This package also contains the change from PR #246 .