### PR TITLE
[4.0] Error in PostgreSQL update SQL

### DIFF
--- a/administrator/components/com_patchtester/install/sql/updates/postgresql/4.0.0.sql
+++ b/administrator/components/com_patchtester/install/sql/updates/postgresql/4.0.0.sql
@@ -2,5 +2,5 @@ CREATE TABLE IF NOT EXISTS "#__patchtester_chain" (
   "id" serial NOT NULL,
   "insert_id" bigint NOT NULL,
   "pull_id" bigint NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY ("id")
 );


### PR DESCRIPTION
#### Summary of Changes

Fixes SQL error on PostgreSQL.

#### Testing Instructions

Update from 3.0 to 4.0.
`#__patchtester_chain` doesn't exist.
Fixing with Database fixer doesn't work.
With patch it works.