### PR TITLE
Correct implode() argument order

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -398,7 +398,7 @@ class PullsModel extends AbstractModel
 					$this->getDb()->quote($branch),
 				);
 
-				$data[] = implode($pullData, ',');
+				$data[] = implode(',', $pullData);
 			}
 		}
 


### PR DESCRIPTION
#### Summary of Changes

Corrects `implode()` argument order to fix notices in PHP 7.4.

#### Testing Instructions

Code review.