### PR TITLE
[PHP 7.4] Deprecated:  implode(): Passing glue string after array is …

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -398,7 +398,7 @@ class PullsModel extends AbstractModel
 					$this->getDb()->quote($branch),
 				);
 
-				$data[] = implode($pullData, ',');
+				$data[] = implode(',', $pullData);
 			}
 		}
 


### PR DESCRIPTION
…deprecated in 7.4

PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters


#### Summary of Changes
Swapped

#### Testing Instructions
run under php 7.4.x
