### PR TITLE
Delete autoload_psr4.php when applying or reverting patches on Joomla 4 and later.

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -338,7 +338,7 @@ class PullModel extends AbstractModel
 		$this->appendPatchChain($lastInserted, $id);
 
 		// On Joomla 4 or later, remove the autoloader file
-		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (version_compare(JVERSION, '4', 'ge') && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
 		{
 			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
 		}
@@ -513,7 +513,7 @@ class PullModel extends AbstractModel
 		$this->saveAppliedPatch($pull->number, $parsedFiles, $pull->head->sha);
 
 		// On Joomla 4 or later, remove the autoloader file
-		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (version_compare(JVERSION, '4', 'ge') && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
 		{
 			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
 		}
@@ -726,7 +726,7 @@ class PullModel extends AbstractModel
 		Folder::delete($backupsPath);
 
 		// On Joomla 4 or later, remove the autoloader file
-		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (version_compare(JVERSION, '4', 'ge') && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
 		{
 			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
 		}
@@ -841,7 +841,7 @@ class PullModel extends AbstractModel
 		}
 
 		// On Joomla 4 or later, remove the autoloader file
-		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (version_compare(JVERSION, '4', 'ge') && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
 		{
 			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
 		}

--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -337,6 +337,12 @@ class PullModel extends AbstractModel
 		// Write or create patch chain for correct order of patching
 		$this->appendPatchChain($lastInserted, $id);
 
+		// On Joomla 4 or later, remove the autoloader file
+		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		{
+			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+		}
+
 		// Change the media version
 		$version = new Version;
 		$version->refreshMediaVersion();
@@ -505,6 +511,12 @@ class PullModel extends AbstractModel
 		}
 
 		$this->saveAppliedPatch($pull->number, $parsedFiles, $pull->head->sha);
+
+		// On Joomla 4 or later, remove the autoloader file
+		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		{
+			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+		}
 
 		// Change the media version
 		$version = new Version;
@@ -713,6 +725,12 @@ class PullModel extends AbstractModel
 
 		Folder::delete($backupsPath);
 
+		// On Joomla 4 or later, remove the autoloader file
+		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		{
+			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+		}
+
 		// Change the media version
 		$version = new Version;
 		$version->refreshMediaVersion();
@@ -820,6 +838,12 @@ class PullModel extends AbstractModel
 
 					break;
 			}
+		}
+
+		// On Joomla 4 or later, remove the autoloader file
+		if (version_compare(JVERSION, '4', 'ge' && file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		{
+			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
 		}
 
 		// Change the media version


### PR DESCRIPTION
Pull Request for Issue #257 .

#### Summary of Changes

Delete file `libraries/autoload_psr4.php` when applying or reverting patches on Joomla 4 and later.

#### Testing Instructions

Patched Patchtester package for testing this PR can be downloaded from [https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-5.zip](https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-5.zip).

Check that applying and reverting CMS patches on Joomla 4 which move around class files or rename classes works, and after having applied such a patch neither backend nor frontend are broken in a way which could be fixed by deleting file `libraries/autoload_psr4.php`.

Currently available examples of such PR's:
[https://github.com/joomla/joomla-cms/pull/27643](https://github.com/joomla/joomla-cms/pull/27643)
[https://github.com/joomla/joomla-cms/pull/27648](https://github.com/joomla/joomla-cms/pull/27648)

Or maybe just check time stamp of the `libraries/autoload_psr4.php`, then apply a patch for J4 which requires CI system, i.e. has some scss change, and check the time stamp again, then wait a minute or more and revert the patch, and check timestamp again. Result: Time stamp changes with apply and revert.

Check that applying and reverting other CMS patches on Joomla 4 works as well as without this PR.