### PR TITLE
Update path to autoloader file to changes in J4

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullModel.php
@@ -265,10 +265,10 @@ class PullModel extends AbstractModel
 		// Write or create patch chain for correct order of patching
 		$this->appendPatchChain($lastInserted, $id);
 
-		// On Joomla 4 or later, remove the autoloader file
-		if (file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		// Remove the autoloader file
+		if (file_exists(JPATH_CACHE . '/autoload_psr4.php'))
 		{
-			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+			File::delete(JPATH_CACHE . '/autoload_psr4.php');
 		}
 
 		// Change the media version
@@ -590,10 +590,10 @@ class PullModel extends AbstractModel
 
 		$this->saveAppliedPatch($pull->number, $parsedFiles, $pull->head->sha);
 
-		// On Joomla 4 or later, remove the autoloader file
-		if (file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		// Remove the autoloader file
+		if (file_exists(JPATH_CACHE . '/autoload_psr4.php'))
 		{
-			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+			File::delete(JPATH_CACHE . '/autoload_psr4.php');
 		}
 
 		// Change the media version
@@ -831,9 +831,9 @@ class PullModel extends AbstractModel
 		Folder::delete($backupsPath);
 
 		// Remove the autoloader file
-		if (file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (file_exists(JPATH_CACHE . '/autoload_psr4.php'))
 		{
-			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+			File::delete(JPATH_CACHE . '/autoload_psr4.php');
 		}
 
 		// Change the media version
@@ -1028,9 +1028,9 @@ class PullModel extends AbstractModel
 		}
 
 		// Remove the autoloader file
-		if (file_exists(JPATH_LIBRARIES . '/autoload_psr4.php'))
+		if (file_exists(JPATH_CACHE . '/autoload_psr4.php'))
 		{
-			File::delete(JPATH_LIBRARIES . '/autoload_psr4.php');
+			File::delete(JPATH_CACHE . '/autoload_psr4.php');
 		}
 
 		// Change the media version


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

With PR #258 deletion of autoload_psr4.php was added to the Patchtester for J4.

With PR [https://github.com/joomla/joomla-cms/pull/28436](https://github.com/joomla/joomla-cms/pull/28436) the location of that file has changed in the CMS.

This PR here adapts the Patchtester to that change.

#### Testing Instructions

Code review.

Or use following patched patchtester package and check that applying and reverting patches with or without CI server option still works as well or bad as before: [https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-7.zip](https://test5.richard-fath.de/com_patchtester_4.0.0.beta3-dev-7.zip).