### PR TITLE
Avoid github deprecation mails when using the token

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Helper.php
+++ b/administrator/components/com_patchtester/PatchTester/Helper.php
@@ -46,7 +46,7 @@ abstract class Helper
 		// If an API token is set in the params, use it for authentication
 		if ($params->get('gh_token', ''))
 		{
-			$options->set('gh.token', $params->get('gh_token', ''));
+			$options->set('headers', ['Authorization' => 'token ' . $params->get('gh_token', '')]);
 		}
 		// Set the username and password if set in the params
 		elseif ($params->get('gh_user', '') && $params->get('gh_password'))


### PR DESCRIPTION
### Summary of Changes

Pass the token via the header and not via query parameter.

#### Testing Instructions

Install the latest patchtester
setup token access
do some requests to github
github sends you this

![image](https://user-images.githubusercontent.com/2596554/86529504-6dde5e80-beb1-11ea-8989-3782c39b780b.png)

apply the patch
this should not happen any more

A change to the upstream project has been redjected so we have to fix that locally for now i guess.