### PR TITLE
Fix SQL error missing column "pulls.applied" breaking the "Applied" filter

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -273,7 +273,7 @@ class PullsModel extends AbstractModel
 			// Not applied patches have a NULL value, so build our value part of the query based on this
 			$value = $applied === 'no' ? ' IS NULL' : ' = 1';
 
-			$query->where($db->quoteName('pulls.applied') . $value);
+			$query->where($db->quoteName('applied') . $value);
 		}
 
 		// Filter for branch


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

Since commit https://github.com/joomla-extensions/patchtester/commit/4592caba1e4d6a86701828002f93d9a905d4cb3f , the filter for applied or not applied is broken.

This PR here fixes it.

#### Testing Instructions

Install Patchtester 4 with the current development status (master branch). You can find a package here: [https://test5.richard-fath.de/com_patchtester_4.0.0.rc4-dev.zip](https://test5.richard-fath.de/com_patchtester_4.0.0.rc4-dev.zip).

Then fill in your GitHub access token in the options and fetch the pull requests.

Then use the filter for applied or not applied patches.

### Actual result

It fails with SQL error about not existing database column "pulls.applied". 

### Expected result

It works.