### PR TITLE
Duplicate description

### DIFF
--- a/administrator/components/com_patchtester/config.xml
+++ b/administrator/components/com_patchtester/config.xml
@@ -79,6 +79,7 @@
 				type="password"
 				label="COM_PATCHTESTER_FIELD_GH_PASSWORD_LABEL"
 				description="COM_PATCHTESTER_FIELD_GH_PASSWORD_DESC"
+				hiddenDescription="true"
 				autocomplete="off"
 				default=""
 				showon="gh_auth:credentials"


### PR DESCRIPTION
Prevents double display of the description of the password field

### Before
![image](https://user-images.githubusercontent.com/1296369/97104248-3c7cdf00-16aa-11eb-9a17-20e713dcc175.png)

### After
![image](https://user-images.githubusercontent.com/1296369/97104232-240cc480-16aa-11eb-9d4e-a295d56e9893.png)
