### PR TITLE
Fix Fetch PRs

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/PatchTester/Model/PullsModel.php
@@ -535,9 +535,9 @@ class PullsModel extends AbstractModel
 			// Default this to being a single page of results
 			$lastPage = 1;
 
-			if (isset($pullsResponse->headers['Link']))
+			if (isset($pullsResponse->headers['link']))
 			{
-				$linkHeader = $pullsResponse->headers['Link'];
+				$linkHeader = $pullsResponse->headers['link'];
 
 				// The `joomla/http` 2.0 package uses PSR-7 Responses which has a different format for headers, check for this
 				if (is_array($linkHeader))


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes
I use patch tester for testing PR on Joomla 4 and found that it could not fetch all the PRs (only 5 pages, mean 100 PRs). I tried to debug code and it seems Link needs to be changed to link (l in lower case). I made that change and were able to fetch all PRs.

#### Testing Instructions
1. Try to fetch PRs
2. Before patch: Only latest 100 PRs are fetched. After patch, all PRs are fetched.