### PR TITLE
adjust tooltip id by

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default.php
+++ b/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default.php
@@ -58,7 +58,7 @@ if ($filterApplied || $filterBranch || $filterLabel || $filterRtc || $filterNpm)
 										<?php echo Text::_('COM_PATCHTESTER_FILTER_SEARCH_DESCRIPTION'); ?>
 									</label>
 									<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="form-control" placeholder="<?php echo Text::_('JSEARCH_FILTER'); ?>">
-									<div role="tooltip" id="filter[search]-desc">
+									<div role="tooltip" id="filter_search-desc">
 										<?php echo $this->escape(Text::_('COM_PATCHTESTER_FILTER_SEARCH_DESCRIPTION')); ?>
 									</div>
 									<span class="input-group-append">


### PR DESCRIPTION
Pull Request for Issue #335 .

## Summary of Changes

- changing id of tooltip element from `filter[search]-desc` to `filter-search-desc`
- doing so makes it the same implementation as done by Joomla com_content article overview

## Testing Instructions

### before
![Schermafbeelding 2021-12-15 om 19 05 58](https://user-images.githubusercontent.com/639822/146242235-475928f8-1cd6-4ad5-a0e4-f36a0c1178ab.png)

### after
![Schermafbeelding 2021-12-15 om 19 14 33](https://user-images.githubusercontent.com/639822/146242287-dec714e1-ae9a-4e67-bdb4-2965c1ab4c65.png)

