### PR TITLE
fixes hover issues

### DIFF
--- a/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default_items.php
+++ b/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default_items.php
@@ -40,14 +40,14 @@ foreach ($this->items as $i => $item) :
            </div>
          <div class="row">
               <div class="col-md-auto">
-                    <a class="badge bg-info" href="<?php echo $item->pull_url; ?>" target="_blank">
+                    <a class="badge btn-info" href="<?php echo $item->pull_url; ?>" target="_blank">
                         <?php echo Text::_('COM_PATCHTESTER_VIEW_ON_GITHUB'); ?>
                  </a>
                </div>
                 <?php if ($this->trackerAlias) :
                     ?>
              <div class="col-md-auto">
-                  <a class="badge bg-info"
+                  <a class="badge btn-info btn-sm"
                        href="https://issues.joomla.org/tracker/<?php echo $this->trackerAlias; ?>/<?php echo $item->pull_id; ?>"
                      target="_blank">
                         <?php echo Text::_('COM_PATCHTESTER_VIEW_ON_JOOMLA_ISSUE_TRACKER'); ?>
@@ -58,7 +58,7 @@ foreach ($this->items as $i => $item) :
                 <?php if ($item->applied) :
                     ?>
                   <div class="col-md-auto">
-                        <span class="badge bg-info"><?php echo Text::sprintf('COM_PATCHTESTER_APPLIED_COMMIT_SHA', substr($item->sha, 0, 10)); ?></span>
+                        <span class="badge btn-info"><?php echo Text::sprintf('COM_PATCHTESTER_APPLIED_COMMIT_SHA', substr($item->sha, 0, 10)); ?></span>
                  </div>
                     <?php
                 endif; ?>

--- a/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default_items.php
+++ b/administrator/components/com_patchtester/PatchTester/View/Pulls/tmpl/default_items.php
@@ -47,7 +47,7 @@ foreach ($this->items as $i => $item) :
                 <?php if ($this->trackerAlias) :
                     ?>
              <div class="col-md-auto">
-                  <a class="badge btn-info btn-sm"
+                  <a class="badge btn-info"
                        href="https://issues.joomla.org/tracker/<?php echo $this->trackerAlias; ?>/<?php echo $item->pull_id; ?>"
                      target="_blank">
                         <?php echo Text::_('COM_PATCHTESTER_VIEW_ON_JOOMLA_ISSUE_TRACKER'); ?>


### PR DESCRIPTION
Pull Request for Issue # .
#340 
#### Summary of Changes
By default badges do not have hover styling 
```
Examples 
Badges scale to match the size of the immediate parent element by using relative font sizing and em units. As of v5, badges no longer have focus or hover styles for links.
```
so in order to do so we have the choice of creating a new .css file and adding our own stylings or use the inbuilt bs5 button behavior.  I chose the latter.
The effect is subtle but this is due to how atum handles things.  This issue would be best for @JAT

#### Testing Instructions
install patch tester.
apply patch
notice the subtle shift in background color & flicker on hover
![image](https://user-images.githubusercontent.com/1850089/195531150-40eb5fc1-aff2-4f4b-b553-a841a7884e0c.png)

