### PR TITLE
update crowdin action

### DIFF
--- a/.github/workflows/crowdin-wf.yml
+++ b/.github/workflows/crowdin-wf.yml
@@ -22,7 +22,7 @@ jobs:
     
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: crowdin action
-      uses: crowdin/github-action@1.1.2
+      uses: crowdin/github-action@v1.10.0
       with:
         # Upload sources to Crowdin
         upload_sources: true


### PR DESCRIPTION
Translations are not up to date; Github Action for crowdin is not running
![image](https://github.com/joomla-extensions/patchtester/assets/66922325/0aa560fc-5150-4195-840d-f908fd2c2bda)

Update crowdin action; for reference see [commit](https://github.com/joomla/joomla.org/commit/1735af1f6903d361b2b3e0a60d8d0c090116b53d) in https://github.com/joomla/joomla.org

@roland-d 
