### PR TITLE
update crowdin action

### DIFF
--- a/.github/workflows/crowdin-wf.yml
+++ b/.github/workflows/crowdin-wf.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   synchronize-with-crowdin:
+    if: (github.event_name == 'schedule' && github.repository == 'joomla-extensions/patchtester') || (github.event_name != 'schedule')
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
no scheduled execution in forks because secrets are missing
![image](https://github.com/joomla-extensions/patchtester/assets/66922325/205dff0f-8579-4296-9339-9e4c0284e496)

@roland-d
