### PR TITLE
update creation date format

### DIFF
--- a/administrator/components/com_patchtester/patchtester.xml
+++ b/administrator/components/com_patchtester/patchtester.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension type="component" version="4.0" method="upgrade">
+<extension type="component" method="upgrade">
 	<name>com_patchtester</name>
 	<author>Joomla! Project</author>
-	<creationDate>03-August-2023</creationDate>
+	<creationDate>2023-08-03</creationDate>
 	<copyright>(C) 2011 - 2012 Ian MacLennan, (C) 2013 - 2018 Open Source Matters, Inc. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later</license>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/build/patchtester/release.php
+++ b/build/patchtester/release.php
@@ -77,7 +77,7 @@ $version = array(
     'main'      => $versionSubParts[0] . '.' . $versionSubParts[1],
     'release'   => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
     'dev_devel' => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
-    'credate'   => date('d-F-Y'),
+    'credate'   => date('Y-m-d'),
 );
 
 // Prints version information.


### PR DESCRIPTION
see https://github.com/joomla/joomla-cms/pull/27162 for creation date

alternative only `'Y-m'`

remove version attribute (no longer used since 4.0)
