### PR TITLE
Fix replacing every src string / Issue from Weblinks repo

### DIFF
--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -783,7 +783,7 @@ class PullModel extends BaseDatabaseModel
             $filePath            = explode('/', $prodFileName);
             // Remove the `src` here to match the CMS paths if needed
             if ($filePath[0] === 'src') {
-                $prodFileName = preg_replace('/^src\\//', '', $prodFileName, 1);;
+                $prodFileName = preg_replace('/^src\\//', '', $prodFileName, 1);
             }
 
             if ($prodRenamedFileName) {

--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -783,17 +783,18 @@ class PullModel extends BaseDatabaseModel
             $filePath            = explode('/', $prodFileName);
             // Remove the `src` here to match the CMS paths if needed
             if ($filePath[0] === 'src') {
-                $prodFileName = str_replace('src/', '', $prodFileName);
+                $prodFileName = preg_replace('/^src\\//', '', $prodFileName, 1);;
             }
 
             if ($prodRenamedFileName) {
                 $filePath = explode('/', $prodRenamedFileName);
                 // Remove the `src` here to match the CMS paths if needed
                 if ($filePath[0] === 'src') {
-                    $prodRenamedFileName = str_replace(
-                        'src/',
+                    $prodRenamedFileName = preg_replace(
+                        '/^src\\//',
                         '',
-                        $prodRenamedFileName
+                        $prodRenamedFileName,
+                        1
                     );
                 }
             }

--- a/administrator/components/com_patchtester/tmpl/pulls/default_items.php
+++ b/administrator/components/com_patchtester/tmpl/pulls/default_items.php
@@ -137,27 +137,27 @@ foreach ($this->items as $i => $item) :
             endif; ?>
       </td>
       <td class="text-center">
-          <?php $hideButton = function($labels) {
-                foreach ($labels as $label) {
-                    if (in_array(strtolower($label->name), ['npm resource changed', 'composer dependency changed', 'rtc'])) {
-                        return true;
-                    }
-                }
+          <?php $hideButton = function ($labels) {
+    foreach ($labels as $label) {
+        if (in_array(strtolower($label->name), ['npm resource changed', 'composer dependency changed', 'rtc'])) {
+            return true;
+        }
+    }
 
                 return false;
           };?>
           <?php if ($this->settings->get('advanced', 0) || !$hideButton($item->labels)) : ?>
-              <?php if ($item->applied) :
-                  ?>
+                <?php if ($item->applied) :
+                    ?>
                   <button type="button" class="btn btn-sm btn-success submitPatch"
                           data-task="revert" data-id="<?php echo (int) $item->applied; ?>"><?php echo Text::_('COM_PATCHTESTER_REVERT_PATCH'); ?></button>
-                  <?php
-              else :
-                  ?>
+                    <?php
+                else :
+                    ?>
                 <button type="button" class="btn btn-sm btn-primary submitPatch"
                           data-task="apply" data-id="<?php echo (int) $item->pull_id; ?>"><?php echo Text::_('COM_PATCHTESTER_APPLY_PATCH'); ?></button>
-                  <?php
-              endif; ?>
+                    <?php
+                endif; ?>
           <?php endif; ?>
       </td>
   </tr>


### PR DESCRIPTION
Pull Request for Issue [591 from weblinks](https://github.com/joomla-extensions/weblinks/issues/591).

#### Summary of Changes

When using `patchtester` to test components, it replaces every `/src` folder with empty string (it removes it from the path) but in reality we only need to remove the first `/src` occurrence only, otherwise if the the pull request we checking the changes from has another `/src` in it's path its going to get removed and we get this error
 `The file marked for modification does not exist`, like the issue in the link above

#### Testing Instructions

1. Login as Admin
2. Fetch data from the Weblinks GitHub Repository using patchtester
3. Apply a patch from any pull request that includes file path changes containing `/src`
