### PR TITLE
Fix GitHub API response handling for Joomla Framework version 4

### DIFF
--- a/administrator/components/com_patchtester/src/Controller/StartfetchController.php
+++ b/administrator/components/com_patchtester/src/Controller/StartfetchController.php
@@ -52,7 +52,7 @@ class StartfetchController extends BaseController
         // Make sure we can fetch the data from GitHub - throw an error on < 10 available requests
         try {
             $rateResponse = Helper::initializeGithub()->getRateLimit();
-            $rate         = json_decode($rateResponse->body);
+            $rate         = json_decode($rateResponse->getBody());
         } catch (\Exception $e) {
             $response = new JsonResponse(new \Exception(Text::sprintf('COM_PATCHTESTER_COULD_NOT_CONNECT_TO_GITHUB', $e->getMessage()), $e->getCode(), $e));
             $this->app->sendHeaders();

--- a/administrator/components/com_patchtester/src/GitHub/GitHub.php
+++ b/administrator/components/com_patchtester/src/GitHub/GitHub.php
@@ -3,7 +3,7 @@
 /**
  * Patch testing component for the Joomla! CMS
  *
- * @copyright  Copyright (C) 2011 - 2012 Ian MacLennan, Copyright (C) 2013 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2011 - 2012 Ian MacLennan, Copyright (C) 2013 - 2025 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later
  */
 
@@ -166,15 +166,15 @@ class GitHub
         int $expectedCode = 200
     ): Response {
         // Validate the response code.
-        if ($response->code != $expectedCode) {
+        if ($response->getStatusCode() != $expectedCode) {
             // Decode the error response and throw an exception.
-            $body  = json_decode($response->body);
+            $body  = json_decode((string) $response->getBody(), true);
             $error = $body->error ?? ($body->message ?? 'Unknown Error');
 
             throw new UnexpectedResponse(
                 $response,
                 $error,
-                $response->code
+                $response->getStatusCode()
             );
         }
 

--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -347,7 +347,7 @@ class PullModel extends BaseDatabaseModel
                 $this->getState()->get('github_repo'),
                 $id
             );
-            $pull         = json_decode($pullResponse->body, false);
+            $pull         = json_decode($pullResponse->getBody(), false);
         } catch (UnexpectedResponse $exception) {
             throw new RuntimeException(
                 Text::sprintf(
@@ -587,7 +587,7 @@ class PullModel extends BaseDatabaseModel
                             urlencode($pull->head->ref)
                         );
                         $contents         = json_decode(
-                            $contentsResponse->body,
+                            $contentsResponse->getBody(),
                             false
                         );
                         // In case encoding type ever changes

--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -319,7 +319,7 @@ class PullModel extends BaseDatabaseModel
     {
         try {
             $rateResponse = $github->getRateLimit();
-            $rate         = json_decode($rateResponse->body, false);
+            $rate         = json_decode($rateResponse->getBody(), false);
         } catch (UnexpectedResponse $exception) {
             throw new RuntimeException(
                 Text::sprintf(

--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -3,7 +3,7 @@
 /**
  * Patch testing component for the Joomla! CMS
  *
- * @copyright  Copyright (C) 2011 - 2012 Ian MacLennan, Copyright (C) 2013 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2011 - 2012 Ian MacLennan, Copyright (C) 2013 - 2025 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later
  */
 

--- a/administrator/components/com_patchtester/tmpl/pulls/default_items.php
+++ b/administrator/components/com_patchtester/tmpl/pulls/default_items.php
@@ -137,27 +137,27 @@ foreach ($this->items as $i => $item) :
             endif; ?>
       </td>
       <td class="text-center">
-          <?php $hideButton = function($labels) {
-                foreach ($labels as $label) {
-                    if (in_array(strtolower($label->name), ['npm resource changed', 'composer dependency changed', 'rtc'])) {
-                        return true;
-                    }
-                }
+          <?php $hideButton = function ($labels) {
+    foreach ($labels as $label) {
+        if (in_array(strtolower($label->name), ['npm resource changed', 'composer dependency changed', 'rtc'])) {
+            return true;
+        }
+    }
 
                 return false;
           };?>
           <?php if ($this->settings->get('advanced', 0) || !$hideButton($item->labels)) : ?>
-              <?php if ($item->applied) :
-                  ?>
+                <?php if ($item->applied) :
+                    ?>
                   <button type="button" class="btn btn-sm btn-success submitPatch"
                           data-task="revert" data-id="<?php echo (int) $item->applied; ?>"><?php echo Text::_('COM_PATCHTESTER_REVERT_PATCH'); ?></button>
-                  <?php
-              else :
-                  ?>
+                    <?php
+                else :
+                    ?>
                 <button type="button" class="btn btn-sm btn-primary submitPatch"
                           data-task="apply" data-id="<?php echo (int) $item->pull_id; ?>"><?php echo Text::_('COM_PATCHTESTER_APPLY_PATCH'); ?></button>
-                  <?php
-              endif; ?>
+                    <?php
+                endif; ?>
           <?php endif; ?>
       </td>
   </tr>


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

Fix for fetching Github API data after Joomla Framework update.

Ref: 
https://github.com/joomla/joomla-cms/pull/45825
https://github.com/joomla/joomla-cms/pull/45827

#### Testing Instructions
