### PR TITLE
Fix GitHub API response handling for Joomla Framework 4

### DIFF
--- a/administrator/components/com_patchtester/src/Controller/StartfetchController.php
+++ b/administrator/components/com_patchtester/src/Controller/StartfetchController.php
@@ -52,7 +52,7 @@ class StartfetchController extends BaseController
         // Make sure we can fetch the data from GitHub - throw an error on < 10 available requests
         try {
             $rateResponse = Helper::initializeGithub()->getRateLimit();
-            $rate         = json_decode($rateResponse->getBody());
+            $rate         = json_decode((string) $rateResponse->getBody());
         } catch (\Exception $e) {
             $response = new JsonResponse(new \Exception(Text::sprintf('COM_PATCHTESTER_COULD_NOT_CONNECT_TO_GITHUB', $e->getMessage()), $e->getCode(), $e));
             $this->app->sendHeaders();

--- a/administrator/components/com_patchtester/src/GitHub/GitHub.php
+++ b/administrator/components/com_patchtester/src/GitHub/GitHub.php
@@ -46,7 +46,7 @@ class GitHub
      *
      * @since   3.0.0
      */
-    public function __construct(Registry $options = null, Http $client = null)
+    public function __construct(Registry|null $options = null, Http|null $client = null)
     {
         $this->options = $options ?: new Registry();
         $this->client  = $client ?: HttpFactory::getHttp($options);

--- a/administrator/components/com_patchtester/src/GitHub/GitHub.php
+++ b/administrator/components/com_patchtester/src/GitHub/GitHub.php
@@ -46,7 +46,7 @@ class GitHub
      *
      * @since   3.0.0
      */
-    public function __construct(Registry|null $options = null, Http|null $client = null)
+    public function __construct(?Registry $options = null, ?Http $client = null)
     {
         $this->options = $options ?: new Registry();
         $this->client  = $client ?: HttpFactory::getHttp($options);

--- a/administrator/components/com_patchtester/src/Model/PullModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullModel.php
@@ -319,7 +319,7 @@ class PullModel extends BaseDatabaseModel
     {
         try {
             $rateResponse = $github->getRateLimit();
-            $rate         = json_decode($rateResponse->getBody(), false);
+            $rate         = json_decode((string) $rateResponse->getBody(), false);
         } catch (UnexpectedResponse $exception) {
             throw new RuntimeException(
                 Text::sprintf(
@@ -347,7 +347,7 @@ class PullModel extends BaseDatabaseModel
                 $this->getState()->get('github_repo'),
                 $id
             );
-            $pull         = json_decode($pullResponse->getBody(), false);
+            $pull         = json_decode((string) $pullResponse->getBody(), false);
         } catch (UnexpectedResponse $exception) {
             throw new RuntimeException(
                 Text::sprintf(
@@ -587,7 +587,7 @@ class PullModel extends BaseDatabaseModel
                             urlencode($pull->head->ref)
                         );
                         $contents         = json_decode(
-                            $contentsResponse->getBody(),
+                            (string) $contentsResponse->getBody(),
                             false
                         );
                         // In case encoding type ever changes
@@ -723,7 +723,7 @@ class PullModel extends BaseDatabaseModel
             $id,
             $page
         );
-        $files         = array_merge($files, json_decode($filesResponse->getBody(), false));
+        $files         = array_merge($files, json_decode((string) $filesResponse->getBody(), false));
         $lastPage      = 1;
         $headers       = $filesResponse->getHeaders();
 

--- a/administrator/components/com_patchtester/src/Model/PullsModel.php
+++ b/administrator/components/com_patchtester/src/Model/PullsModel.php
@@ -345,7 +345,7 @@ class PullsModel extends ListModel
                 $page,
                 $batchSize
             );
-            $pulls         = json_decode($pullsResponse->body);
+            $pulls         = json_decode((string) $pullsResponse->getBody());
         } catch (UnexpectedResponse $exception) {
             throw new RuntimeException(
                 Text::sprintf(
@@ -387,7 +387,7 @@ class PullsModel extends ListModel
         }
 
         // If there are no pulls to insert then bail, assume we're finished
-        if (count($pulls) === 0) {
+        if (empty($pulls)) {
             return ['complete' => true];
         }
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -79,7 +79,7 @@
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/patchtester/releases/download/5.0.0/com_patchtester_5.0.0.zip</downloadurl>
 		</downloads>
-		<sha384>e6bfc039ab4dac753124d79456ff00d51c06d602be84d4b9116d8970fcbd34b7233b592ac9f0ddbc045afa8726c12768</sha384>
+		<sha384>9b51456a819ba30fd904ea1c6f98550889e62c5992e7a4f5b7de384ff31b94d0b7929ecd7cc7dc51732d9a9fb164091c</sha384>
 		<tags>
 			<tag>stable</tag>
 		</tags>

--- a/manifest.xml
+++ b/manifest.xml
@@ -79,7 +79,7 @@
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/patchtester/releases/download/5.0.0/com_patchtester_5.0.0.zip</downloadurl>
 		</downloads>
-		<sha384>9b51456a819ba30fd904ea1c6f98550889e62c5992e7a4f5b7de384ff31b94d0b7929ecd7cc7dc51732d9a9fb164091c</sha384>
+		<sha384>16f06a344c4584a2defada5aea0217c511a9700a6aad42cb5567b69e1bc2564c53c74782c4095561d155548778159f4e</sha384>
 		<tags>
 			<tag>stable</tag>
 		</tags>


### PR DESCRIPTION
Pull Request for Issue # .

Fix GitHub API response handling

Updated the `<sha384>` hash in `manifest.xml` to reflect the latest release package checksum.

#### Summary of Changes

#### Testing Instructions
